### PR TITLE
Add linting with ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,7 @@
+skip_list:
+  # Using FQDN for modules (e.g. ansible.builtin.copy instead of just copy)
+  # makes the YAML files harder to read.
+  - fqcn-builtins
+  # Since we only build this project locally, we are happy with the default
+  # file permissions.
+  - risky-file-permissions

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,12 @@
+name: Ansible linting
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GitHub workspace environment variable
+        uses: actions/checkout@v2
+      - name: Perform linting of Ansible files
+        uses: ansible-community/ansible-lint-action@main

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 title: Active Directory Certificate Services
 link: https://atea.se
 theme: guzzle_sphinx_theme
-#system_description: Provide X.509 certificates for Windows workstations and employees at Atea.
+# system_description: Provide X.509 certificates for Windows workstations and employees at Atea.
 consultant:
   name: Foo Foobarsson
   company: Atea Sverige AB
@@ -33,7 +33,7 @@ smtp_exit_module:
     #   - NTLM
     #   - Kerberos
     method: Basic
-    use_tls: Yes
+    use_tls: true
     port: 465
     account:
       username: user
@@ -63,7 +63,7 @@ servers:
       existing_backup: Z:\app-RootCA\Backup
     policy:
       high_serial: 0xFFFFFFFF
-      keep_expired_certificates_on_crl: No
+      keep_expired_certificates_on_crl: false
       # Possible choices are:
       #  - RSA4096
       #  - P256
@@ -80,15 +80,15 @@ servers:
       gateway: 192.168.56.1
       os: Windows Server 2022
       dcom_port: 4000
-      web_enrollment: Yes
-      smtp_exit_module: Yes
+      web_enrollment: true
+      smtp_exit_module: true
       location:
         log: C:\Log
         database: C:\Database
         existing_backup: Z:\app-IssuingCA1\Backup
       policy:
         high_serial: 0xFFFFFFFF
-        keep_expired_certificates_on_crl: No
+        keep_expired_certificates_on_crl: false
         # Possible choices are:
         #  - RSA4096
         #  - P256
@@ -106,15 +106,15 @@ servers:
       gateway: 192.168.56.1
       os: Windows Server 2022
       dcom_port: 4000
-      web_enrollment: Yes
-      smtp_exit_module: Yes
+      web_enrollment: true
+      smtp_exit_module: true
       location:
         log: C:\Log
         database: C:\Database
         existing_backup: Z:\app-IssuingCA1\Backup
       policy:
         high_serial: 0xFFFFFFFF
-        keep_expired_certificates_on_crl: No
+        keep_expired_certificates_on_crl: false
         # Possible choices are:
         #  - RSA4096
         #  - P256
@@ -145,29 +145,29 @@ templates:
     description: Certificate for workstations in the domain.
     validity: 365
     renewal_period: 90
-    publish: No
-    use_ec: Yes
+    publish: false
+    use_ec: true
     groups:
       - name: Domain Computers
-        autoenroll: Yes
+        autoenroll: true
     subject:
-      email: No
-      dnsname: Yes
-      upn: No
+      email: false
+      dnsname: true
+      upn: false
   - from: User
     name: Atea User
     description: Certificate for users in the domain.
     validity: 365
     renewal_period: 90
-    publish: Yes
-    use_ec: Yes
+    publish: true
+    use_ec: true
     groups:
       - name: Domain Users
-        autoenroll: Yes
+        autoenroll: true
     subject:
-      email: Yes
-      dnsname: No
-      upn: Yes
+      email: true
+      dnsname: false
+      upn: true
   - name: Legacy User
     description: Legacy template for users.
   - name: Legacy Computer

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,27 +1,35 @@
 - name: Build ADCS documentation
   hosts: localhost
-  gather_facts: False
+  gather_facts: false
   pre_tasks:
     - name: Check if the Naming and Profile Document can be generated
       stat:
         path: files/naming_document
       register: naming_document_data
   tasks:
-    - block:
-      - name: Create release directory
-        file:
-          path: "release"
-          state: directory
-      - name: Create Naming and Profile Document
-        include_role:
-          name: naming_document
-        when: naming_document_data.stat.exists
-      - name: Create installation manual
-        include_role:
-          name: installation_manual
-      - name: Create operations manual
-        include_role:
-          name: operations_manual
+    - name: Execute tasks and roles
+      block:
+        - name: Get shortened commit hash
+          command:
+            # The git module cannot be used here
+            # noqa: command-instead-of-module
+            cmd: git rev-parse --short HEAD
+          register: short_commit_hash
+          changed_when: false
+        - name: Create release directory
+          file:
+            path: release
+            state: directory
+        - name: Create Naming and Profile Document
+          include_role:
+            name: naming_document
+          when: naming_document_data.stat.exists
+        - name: Create installation manual
+          include_role:
+            name: installation_manual
+        - name: Create operations manual
+          include_role:
+            name: operations_manual
       rescue:
         - name: Cleaning up
           file:

--- a/roles/installation_manual/tasks/main.yml
+++ b/roles/installation_manual/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get shortened commit hash
-  command:
-    cmd: git rev-parse --short HEAD
-  register: short_commit_hash
 - name: Generate a secret
   set_fact:
     secret: "{{ lookup('password', '/dev/null length=16') }}"
@@ -35,6 +31,7 @@
 - name: Perform RST linting
   command:
     cmd: doc8 --max-line-length 2000 "{{ role_path }}/_docs/chapters"
+  changed_when: false
 - name: Copy graphics
   copy:
     src: "{{ item }}"
@@ -47,10 +44,11 @@
     dest: '{{ role_path }}/_docs/diagrams/{{ item | basename | regex_replace("\.j2$", "") }}'
   with_fileglob: templates/diagrams/*.py.j2
 - name: Render diagrams
-  shell: python3 {{ item }}
+  command: python3 {{ item }}
   args:
     chdir: "{{ role_path }}/_docs/diagrams"
   with_fileglob: "{{ role_path }}/_docs/diagrams/*.py"
+  changed_when: true
 - name: Create Sphinx configuration
   template:
     src: conf.py.j2
@@ -65,9 +63,10 @@
     - atea.png
     - atea_aligned.png
 - name: Create style for Microsoft Word
-  shell: python3 render.py
+  command: python3 render.py
   args:
     chdir: "{{ role_path }}/files/docxbuilder"
+  changed_when: true
 - name: Copy style for Microsoft Word
   copy:
     src: style.docx

--- a/roles/naming_document/group_vars/sample.yml
+++ b/roles/naming_document/group_vars/sample.yml
@@ -1,21 +1,21 @@
 extras:
   naming_and_profile_document:
-    include_ldif: Yes
-    include_ca_certs: Yes
+    include_ldif: true
+    include_ca_certs: true
     templates:
-    - name: Atea Computer
-      description: Certificate used to authenticate workstations at Atea.
-      # https://diagrams.mingrammer.com/docs/nodes/generic
-      # For example:
-      #
-      #   Mobile: diagrams.generic.device.Mobile
-      #   Client: diagrams.onprem.client.Client
-      #   User: diagrams.onprem.client.User
-      class: diagrams.onprem.client.User
-    - name: Atea User
-      description: Certificate used to authenticate employees at Atea.
+      - name: Atea Computer
+        description: Certificate used to authenticate workstations at Atea.
+        # https://diagrams.mingrammer.com/docs/nodes/generic
+        # For example:
+        #
+        #   Mobile: diagrams.generic.device.Mobile
+        #   Client: diagrams.onprem.client.Client
+        #   User: diagrams.onprem.client.User
+        class: diagrams.onprem.client.User
+      - name: Atea User
+        description: Certificate used to authenticate employees at Atea.
     certificate_authorities:
-    - name: R1
-      description: Trust anchor for Atea's public key infrastructure.
-    - name: ICA1
-      description: Issuing CA for Atea's public key infrastructure.
+      - name: R1
+        description: Trust anchor for Atea's public key infrastructure.
+      - name: ICA1
+        description: Issuing CA for Atea's public key infrastructure.

--- a/roles/naming_document/tasks/main.yml
+++ b/roles/naming_document/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get shortened commit hash
-  command:
-    cmd: git rev-parse --short HEAD
-  register: short_commit_hash
 - name: Create directory structure
   file:
     state: directory
@@ -18,13 +14,20 @@
   with_fileglob:
     - "graphics/*.png"
 - name: Parse LDIF configuration
-  shell:
-    cmd: python3 {{ role_path }}/files/parse.py --file {{ playbook_dir }}/files/naming_document/Configuration.ldf
+  command:
+    cmd: >
+      python3 {{ role_path }}/files/parse.py
+        --file {{ playbook_dir }}/files/naming_document/Configuration.ldf
   register: public_key_services_configuration
+  changed_when: true
 - name: Extract certificate templates from configuration
-  shell:
-    cmd: python3 "{{ role_path }}/roles/naming_document/extract_templates.py --file {{ playbook_dir }}/files/Configuration.ldf --output-directory {{ playbook_dir }}/files/naming_document/ldif
+  command:
+    cmd: >
+      python3 "{{ role_path }}/roles/naming_document/extract_templates.py
+        --file {{ playbook_dir }}/files/Configuration.ldf
+        --output-directory {{ playbook_dir }}/files/naming_document/ldif
   when: extras.naming_and_profile_document.include_ldif | default(false)
+  changed_when: true
 - name: Create index from template
   template:
     src: index.rst.j2
@@ -38,15 +41,17 @@
 - name: Perform RST linting
   command:
     cmd: doc8 --max-line-length 2000 "{{ role_path }}/_docs/chapters"
+  changed_when: false
 - name: Copy diagrams scripts
   template:
     src: "{{ item }}"
     dest: '{{ role_path }}/_docs/diagrams/{{ item | basename | regex_replace("\.j2$", "") }}'
   with_fileglob: templates/diagrams/*.py.j2
 - name: Render diagrams
-  shell: python3 {{ item }}
+  command: python3 {{ item }}
   args:
     chdir: "{{ role_path }}/_docs/diagrams"
+  changed_when: true
   with_fileglob: "{{ role_path }}/_docs/diagrams/*.py"
 - name: Create Sphinx configuration
   template:

--- a/roles/operations_manual/tasks/main.yml
+++ b/roles/operations_manual/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get shortened commit hash
-  command:
-    cmd: git rev-parse --short HEAD
-  register: short_commit_hash
 - name: Create directory structure
   file:
     state: directory
@@ -23,6 +19,7 @@
 - name: Perform RST linting
   command:
     cmd: doc8 --max-line-length 2000 "{{ role_path }}/_docs/chapters"
+  changed_when: false
 - name: Copy graphics
   copy:
     src: "{{ item }}"
@@ -43,9 +40,10 @@
     - atea.png
     - atea_aligned.png
 - name: Create style for Microsoft Word
-  shell: python3 render.py
+  command: python3 render.py
   args:
     chdir: "{{ role_path }}/files/docxbuilder"
+  changed_when: true
 - name: Copy style for Microsoft Word
   copy:
     src: style.docx


### PR DESCRIPTION
Fix all problems reported by ``ansible-lint`` and enable linting for pull requests and pushes to main using ``ansible-community/ansible-lint-action``.

Currently, there are 95 failures and 27 warnings present.